### PR TITLE
Derive Debug for enums, convert Display impl to Debug impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@
  *
  */
 
+#[derive(Debug)]
 pub enum Error {
   Append,
   Search,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,6 @@ pub enum ResponseOptional {
   Nonexistent
 }
 
-#[derive(Debug)]
 pub struct Emailbox {
   pub flags: Vec<String>,
   pub permanent_flags: Vec<String>,
@@ -156,7 +155,7 @@ impl Default for Emailbox {
   }
 }
 
-impl fmt::Display for Emailbox {
+impl fmt::Debug for Emailbox {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     write!(f, "Exists: {}\r\nRecent: {}\r\nUnseen: {}\r\nUid validity: {}\r\nUid next: {}\r\nFlags: {}\r\nPermanent flags: {}",
            self.exists_num,
@@ -169,7 +168,6 @@ impl fmt::Display for Emailbox {
   }
 }
 
-#[derive(Debug)]
 pub struct Connection {
   host: String,
   port: u16,
@@ -182,7 +180,7 @@ const NEW_LINE_CODE: u8 = 0x0A;
 const NEW_LINE_FULL_CODE: [u8; 2] = [CARRIAGE_RETURN_CODE, NEW_LINE_CODE];
 const NEW_LINE_FULL_CODE_LEN: usize = 2;
 
-impl fmt::Display for Connection {
+impl fmt::Debug for Connection {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     write!(f, "Connection: host: {}, port: {}, tag prefix: {}, tag sequence number: {}",
            self.host, self.port, Connection::tag_prefix(), self.tag_sequence_number.get())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ use std::fmt;
 
 mod error;
 
+#[derive(Debug)]
 pub enum TcpStreamSecurity {
   Plain,
   StartTls,
@@ -47,6 +48,7 @@ impl TcpStreamSecurity {
   }
 }
 
+#[derive(Debug)]
 pub enum Authentication {
   NormalPassword,
   EncryptedPassword,
@@ -59,18 +61,21 @@ pub enum Authentication {
 }
 
 //todo
+#[derive(Debug)]
 enum TcpStreamEx {
   Plain(TcpStream),
   StartTls(ssl::SslStream<TcpStream>),
   SslTls(ssl::SslStream<TcpStream>)
 }
 
+#[derive(Debug)]
 pub enum Response {
   Ok(Vec<String>),
   No(Vec<String>),
   Bad(Vec<String>)
 }
 
+#[derive(Debug)]
 pub enum ResponseOptional {
   Referral,
   Alert,
@@ -126,6 +131,7 @@ pub enum ResponseOptional {
   Nonexistent
 }
 
+#[derive(Debug)]
 pub struct Emailbox {
   pub flags: Vec<String>,
   pub permanent_flags: Vec<String>,
@@ -163,6 +169,7 @@ impl fmt::Display for Emailbox {
   }
 }
 
+#[derive(Debug)]
 pub struct Connection {
   host: String,
   port: u16,


### PR DESCRIPTION
All types should derive `Debug`. Furthermore, `Display` is meant for things that should be displayed to the end user, and a library like this isn't supposed to decide that. Using `Debug` makes  more sense.